### PR TITLE
fix usage example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,7 +20,7 @@ or(T)(T)()); // => true
 or(T, F)()); // => true
 or(F, T)()); // => true
 or(F, F)()); // => false
-or(F, F)()); // => false
+or(F)(F)()); // => false
 ```
 
 


### PR DESCRIPTION
This fixes an example in usage section
(it was probably a copy-paste error, because the line was the same as the line above).
